### PR TITLE
Fix warnings on Check recent versions workflow

### DIFF
--- a/.github/workflows/check-recent-versions.yml
+++ b/.github/workflows/check-recent-versions.yml
@@ -44,7 +44,7 @@ jobs:
           coverage: none
           tools: composer:v2
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install Composer dependencies
         run: composer install
       - name: Update packages

--- a/.github/workflows/check-recent-versions.yml
+++ b/.github/workflows/check-recent-versions.yml
@@ -36,7 +36,7 @@ jobs:
           EXTENSIONS="$(printf '%s' "${EXTENSIONS% }" | tr ' ' '\n' | sort | uniq | tr '\n' ' ')"
           printf 'done.\n'
           printf 'Found etensions: %s\n' "$EXTENSIONS"
-          printf '{list}={%s}\n' "$EXTENSIONS" >> $GITHUB_OUTPUT
+          printf 'list=%s\n' "$EXTENSIONS" >> $GITHUB_OUTPUT
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -77,7 +77,7 @@ jobs:
           else
             printf 'no changes detected.\n'
           fi
-          printf '{push}={%s}\n' "$PUSH" >> $GITHUB_OUTPUT
+          printf 'push=%s\n' "$PUSH" >> $GITHUB_OUTPUT
       - name: Configure git
         if: steps.check-changes.outputs.push == 'yes'
         run: |

--- a/.github/workflows/check-recent-versions.yml
+++ b/.github/workflows/check-recent-versions.yml
@@ -36,7 +36,7 @@ jobs:
           EXTENSIONS="$(printf '%s' "${EXTENSIONS% }" | tr ' ' '\n' | sort | uniq | tr '\n' ' ')"
           printf 'done.\n'
           printf 'Found etensions: %s\n' "$EXTENSIONS"
-          printf '::set-output name=list::%s\n' "$EXTENSIONS"
+          printf '{list}={%s}\n' "$EXTENSIONS" >> $GITHUB_OUTPUT
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -77,7 +77,7 @@ jobs:
           else
             printf 'no changes detected.\n'
           fi
-          printf '::set-output name=push::%s\n' "$PUSH"
+          printf '{push}={%s}\n' "$PUSH" >> $GITHUB_OUTPUT
       - name: Configure git
         if: steps.check-changes.outputs.push == 'yes'
         run: |


### PR DESCRIPTION
Hello @mlocati 

I've noticed that the Check recent versions workflow raised some weak warnings: 

See annontations on, e.g : https://github.com/mlocati/pecl-info/actions/runs/8698241017

Here is a PR to fix them 

- https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
- https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
 
